### PR TITLE
feat: deploy additional production bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,15 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}
-      - name: Deploy to Cloudflare
+      - name: Deploy to Cloudflare (carpark-production)
         uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.CF_TOKEN }}
           environment: 'carpark-production'
         if: ${{ steps.release.outputs.release_created }}
-        
+      - name: Deploy to Cloudflare (carpark-production-1)
+        uses: cloudflare/wrangler-action@2.0.0
+        with:
+          apiToken: ${{ secrets.CF_TOKEN }}
+          environment: 'carpark-production-1'
+        if: ${{ steps.release.outputs.release_created }}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,6 +21,15 @@ route = { pattern = "https://carpark-prod-0.r2.w3s.link/*", zone_id = "ae60d8f73
 DEBUG = "false"
 FF_TELEMETRY_ENABLED = "true"
 
+[env.carpark-production-1]
+account_id = "fffa4b4363a7e5250af8357087263b3a"
+r2_buckets = [{ binding = "BUCKET", bucket_name = "carpark-prod-1" }]
+route = { pattern = "https://carpark-prod-1.r2.w3s.link/*", zone_id = "ae60d8f737317467ec666dc3851a6277" }
+
+[env.carpark-production-1.vars]
+DEBUG = "false"
+FF_TELEMETRY_ENABLED = "true"
+
 # STAGING!
 [env.carpark-staging]
 account_id = "fffa4b4363a7e5250af8357087263b3a"


### PR DESCRIPTION
This PR deploys an additional public bucket `carpark-prod-1` which will be used by the storacha storage node to store data. This will provide a clean separation from existing, non-storage network data.